### PR TITLE
Creates a basic structure for streaming Kafka jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 *.class
 .DS_Store
 .idea
+streaming-checkpoints

--- a/build-topics.sh
+++ b/build-topics.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+kafka-topics --create --zookeeper localhost:2181/kafka --replication-factor 1 --partitions 1 --topic xadf.compute.documents
+kafka-topics --create --zookeeper localhost:2181/kafka --replication-factor 1 --partitions 1 --topic xadf.compute.effective
+kafka-topics --create --zookeeper localhost:2181/kafka --replication-factor 1 --partitions 1 --topic xadf.compute.applicable

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,29 @@
-lazy val discover_rules = (project in file("discover-rules"))
-lazy val discover_items = (project in file("discover-items"))
-lazy val apply_rule = (project in file("apply-rule"))
+lazy val VERSION_SCALA               = "2.11.11"
+lazy val VERSION_SPARK               = "2.2.0"
+lazy val VERSION_CASSANDRA_CONNECTOR = "2.0.3"
+lazy val VERSION_MONGO_CONNECTOR     = "2.2.0"
+lazy val VERSION_NSCALA_TIME         = "2.18.0"
+lazy val VERSION_TYPESAFE_CONFIG     = "1.2.1"
+lazy val VERSION_FICUS               = "1.1.1"
+
+lazy val settings = Seq(
+  name := "xa-spark-jobs",
+  version := "1.0",
+  organization := "http://xalgorithms.org",
+  scalaVersion := VERSION_SCALA
+)
+lazy val deps = Seq(
+  "org.apache.spark"       %% "spark-core"                % VERSION_SPARK,
+  "org.apache.spark"       %% "spark-streaming"           % VERSION_SPARK,
+  "org.apache.spark"       %% "spark-streaming-kafka-0-8" % VERSION_SPARK,
+  "org.apache.spark"       %% "spark-sql"                 % VERSION_SPARK,
+  "com.datastax.spark"     %% "spark-cassandra-connector" % VERSION_CASSANDRA_CONNECTOR,
+  "org.mongodb.spark"      %% "mongo-spark-connector"     % VERSION_MONGO_CONNECTOR,
+  "com.github.nscala-time" %% "nscala-time"               % VERSION_NSCALA_TIME,
+  "com.typesafe"           %  "config"                    % VERSION_TYPESAFE_CONFIG,
+  "net.ceedubs"            %% "ficus"                     % VERSION_FICUS,
+)
+
+lazy val root = (project in file("."))
+  .settings(settings)
+  .settings(libraryDependencies ++= deps)

--- a/local-spark-submit.sh
+++ b/local-spark-submit.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+spark-submit --class "org.xalgorithms.jobs.$1" --packages datastax:spark-cassandra-connector:2.0.3-s_2.11,com.typesafe:config:1.3.1,org.apache.spark:spark-streaming-kafka-0-8_2.11:2.2.0,net.ceedubs:ficus_2.11:1.1.1 target/scala-2.11/xa-spark-jobs_2.11-1.0.jar

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.4

--- a/spark-execute.sh
+++ b/spark-execute.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sbt package && sbt package && spark-submit --class "org.xalgorithms.jobs.$1" --packages datastax:spark-cassandra-connector:2.0.3-s_2.11,com.typesafe:config:1.3.1,org.apache.spark:spark-streaming-kafka-0-8_2.11:2.2.0,net.ceedubs:ficus_2.11:1.1.1 target/scala-2.11/xa-spark-jobs_2.11-1.0.jar

--- a/spark-execute.sh
+++ b/spark-execute.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sbt package && sbt package && spark-submit --class "org.xalgorithms.jobs.$1" --packages datastax:spark-cassandra-connector:2.0.3-s_2.11,com.typesafe:config:1.3.1,org.apache.spark:spark-streaming-kafka-0-8_2.11:2.2.0,net.ceedubs:ficus_2.11:1.1.1 target/scala-2.11/xa-spark-jobs_2.11-1.0.jar
+sbt package && ./local-spark-submit $1

--- a/src/main/resources/application.json
+++ b/src/main/resources/application.json
@@ -3,10 +3,33 @@
     "application" : {
       "topics" : {
         "input" : "xadf.compute.documents",
-        "output" : "xadf.compute.applications"
+        "output" : "xadf.compute.effective"
       },
       "spark" : {
         "spark.app.name" : "jobs-xa-effective-rules"
+      },
+      "kafka" : {
+        "source" : {
+          "metadata.broker.list" : "localhost:9092"
+        },
+        "sink" : {
+          "bootstrap.servers": "localhost:9092"
+        }
+      },
+      "batch_duration" : "5s",
+      "checkpoint_dir" : "./streaming-checkpoints"
+    },
+    "job" : {
+    }
+  },
+  "ApplicableRules" : {
+    "application" : {
+      "topics" : {
+        "input" : "xadf.compute.effective",
+        "output" : "xadf.compute.applicable"
+      },
+      "spark" : {
+        "spark.app.name" : "jobs-xa-applicable-rules"
       },
       "kafka" : {
         "source" : {

--- a/src/main/resources/application.json
+++ b/src/main/resources/application.json
@@ -1,0 +1,21 @@
+{
+  "EffectiveRules" : {
+    "topics" : {
+      "input" : "xadf.compute.documents",
+      "output" : "xadf.compute.applications"
+    },
+    "spark" : {
+      "spark.app.name" : "jobs-xa-effective-rules"
+    },
+    "kafka" : {
+      "source" : {
+        "metadata.broker.list" : "localhost:9092"
+      },
+      "sink" : {
+        "bootstrap.servers": "localhost:9092"
+      }
+    },
+    "batch_duration" : "5s",
+    "checkpoint_dir" : "./streaming-checkpoints"
+  }
+}

--- a/src/main/resources/application.json
+++ b/src/main/resources/application.json
@@ -1,21 +1,25 @@
 {
   "EffectiveRules" : {
-    "topics" : {
-      "input" : "xadf.compute.documents",
-      "output" : "xadf.compute.applications"
-    },
-    "spark" : {
-      "spark.app.name" : "jobs-xa-effective-rules"
-    },
-    "kafka" : {
-      "source" : {
-        "metadata.broker.list" : "localhost:9092"
+    "application" : {
+      "topics" : {
+        "input" : "xadf.compute.documents",
+        "output" : "xadf.compute.applications"
       },
-      "sink" : {
-        "bootstrap.servers": "localhost:9092"
-      }
+      "spark" : {
+        "spark.app.name" : "jobs-xa-effective-rules"
+      },
+      "kafka" : {
+        "source" : {
+          "metadata.broker.list" : "localhost:9092"
+        },
+        "sink" : {
+          "bootstrap.servers": "localhost:9092"
+        }
+      },
+      "batch_duration" : "5s",
+      "checkpoint_dir" : "./streaming-checkpoints"
     },
-    "batch_duration" : "5s",
-    "checkpoint_dir" : "./streaming-checkpoints"
+    "job" : {
+    }
   }
 }

--- a/src/main/scala/org/xalgorithms/apps/KafkaStreamingApplication.scala
+++ b/src/main/scala/org/xalgorithms/apps/KafkaStreamingApplication.scala
@@ -1,0 +1,110 @@
+package org.xalgorithms.apps
+
+import kafka.serializer.StringDecoder
+import scala.collection.mutable
+import scala.concurrent.duration.FiniteDuration
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
+import org.apache.spark.TaskContext
+import org.apache.spark.streaming.Seconds
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.kafka.KafkaUtils
+
+trait KafkaStreamingApplication {
+  def config: Map[String, String]
+  def batch_duration: FiniteDuration
+  def checkpoint_dir: String
+
+  def with_context(scfg: ApplicationConfig, fn: (SparkContext, StreamingContext, DStream[String]) => DStream[String]): Unit = {
+    val cfg = new SparkConf()
+    config.foreach { case (n, v) => cfg.setIfMissing(n, v) }
+    val ctx = new SparkContext(cfg)
+    val sctx = new StreamingContext(ctx, Seconds(batch_duration.toSeconds))
+    val source = KafkaSource(scfg.kafka_source)
+    val input = source.create(sctx, scfg.topic_input)
+
+    sctx.checkpoint(checkpoint_dir)
+
+    val output = fn(ctx, sctx, input)
+
+    import KafkaSink._
+    output.send(scfg.kafka_sink, scfg.topic_output)
+
+    sctx.start()
+    sctx.awaitTermination()
+  }
+}
+
+case class ApplicationConfig(
+  topic_input: String,
+  topic_output: String,
+  kafka_source: Map[String, String],
+  kafka_sink: Map[String, String],
+  spark: Map[String, String],
+  batch_duration: FiniteDuration,
+  checkpoint_dir: String
+) extends Serializable
+
+class KafkaSource(cfg: Map[String, String]) {
+  def create(ctx: StreamingContext, topic: String): DStream[String] = {
+    KafkaUtils.createDirectStream[String, String, StringDecoder, StringDecoder](
+      ctx, cfg, Set(topic)).map(_._2)
+  }
+}
+
+object KafkaSource {
+  def apply(cfg: Map[String, String]): KafkaSource = new KafkaSource(cfg)
+}
+
+class KafkaSink(@transient private val st: DStream[String]) extends Serializable {
+  private val Producers = mutable.Map[Map[String, Object], KafkaProducer[String, String]]()
+
+  def send(cfg: Map[String, String], topic: String): Unit = {
+    st.foreachRDD { rdd =>
+      rdd.foreachPartition { recs =>
+        val pr = maybeMakeProducer(cfg)
+        val tctx = TaskContext.get
+        
+        val meta = recs.map { rec =>
+          // since we sling DStream[String] and Producer[String,
+          // String], then our records are Strings
+          pr.send(new ProducerRecord(topic, rec))
+        }.toList
+
+        meta.foreach { d => d.get() }
+      }
+    }
+  }
+
+  import scala.collection.JavaConverters._
+
+  def maybeMakeProducer(cfg: Map[String, Object]): KafkaProducer[String, String] = {
+    val default_cfg = Map(
+      "key.serializer" -> "org.apache.kafka.common.serialization.StringSerializer",
+      "value.serializer" -> "org.apache.kafka.common.serialization.StringSerializer"
+    )
+    val local_cfg = default_cfg ++ cfg
+
+    Producers.getOrElseUpdate(
+      local_cfg, {
+        val pr = new KafkaProducer[String, String](local_cfg.asJava)
+        sys.addShutdownHook {
+          pr.close()
+        }
+
+        pr
+      })
+  }
+}
+
+object KafkaSink {
+  import scala.language.implicitConversions
+
+  implicit def createKafkaSink(st: DStream[String]): KafkaSink = {
+    new KafkaSink(st)
+  }
+}

--- a/src/main/scala/org/xalgorithms/jobs/ApplicableRules.scala
+++ b/src/main/scala/org/xalgorithms/jobs/ApplicableRules.scala
@@ -2,7 +2,7 @@ package org.xalgorithms.jobs
 
 import org.xalgorithms.apps._
 
-class EffectiveRules(cfg: ApplicationConfig) extends KafkaStreamingApplication(cfg) {
+class ApplicableRules(cfg: ApplicationConfig) extends KafkaStreamingApplication(cfg) {
   def execute(): Unit = {
     with_context(cfg, { (ctx, sctx, input) =>
       input.map { s => s.reverse }
@@ -10,9 +10,9 @@ class EffectiveRules(cfg: ApplicationConfig) extends KafkaStreamingApplication(c
   }
 }
 
-object EffectiveRules {
+object ApplicableRules {
   def main(args: Array[String]) : Unit = {
-    val job = new EffectiveRules(ApplicationConfig("EffectiveRules"))
+    val job = new ApplicableRules(ApplicationConfig("ApplicableRules"))
     job.execute()
   }
 }

--- a/src/main/scala/org/xalgorithms/jobs/EffectiveRules.scala
+++ b/src/main/scala/org/xalgorithms/jobs/EffectiveRules.scala
@@ -1,0 +1,44 @@
+package org.xalgorithms.jobs
+
+import scala.concurrent.duration.FiniteDuration
+import org.xalgorithms.apps._
+
+class EffectiveRulesJob(cfg: ApplicationConfig) extends KafkaStreamingApplication {
+  override def config: Map[String, String] = cfg.spark
+  override def batch_duration: FiniteDuration = cfg.batch_duration
+  override def checkpoint_dir: String = cfg.checkpoint_dir
+
+  def execute(): Unit = {
+    with_context(cfg, { (ctx, sctx, input) =>
+      input.map { s => s.reverse }
+    })
+  }
+}
+
+object EffectiveRulesJob {
+  def main(args: Array[String]) : Unit = {
+    val job = new EffectiveRulesJob(EffectiveRulesJobConfig())
+    job.execute()
+  }
+}
+
+object EffectiveRulesJobConfig {
+  import com.typesafe.config.Config
+  import com.typesafe.config.ConfigFactory
+  import net.ceedubs.ficus.Ficus._
+
+  def apply(): ApplicationConfig = apply(ConfigFactory.load)
+
+  def apply(app_cfg: Config): ApplicationConfig = {
+    val cfg = app_cfg.getConfig("EffectiveRules")
+    new ApplicationConfig(
+      cfg.as[String]("topics.input"),
+      cfg.as[String]("topics.output"),
+      cfg.as[Map[String, String]]("kafka.source"),
+      cfg.as[Map[String, String]]("kafka.sink"),
+      cfg.as[Map[String, String]]("spark"),
+      cfg.as[FiniteDuration]("batch_duration"),
+      cfg.as[String]("checkpoint_dir")
+    )
+  }
+}

--- a/src/main/scala/org/xalgorithms/jobs/EffectiveRules.scala
+++ b/src/main/scala/org/xalgorithms/jobs/EffectiveRules.scala
@@ -1,13 +1,8 @@
 package org.xalgorithms.jobs
 
-import scala.concurrent.duration.FiniteDuration
 import org.xalgorithms.apps._
 
-class EffectiveRulesJob(cfg: ApplicationConfig) extends KafkaStreamingApplication {
-  override def config: Map[String, String] = cfg.spark
-  override def batch_duration: FiniteDuration = cfg.batch_duration
-  override def checkpoint_dir: String = cfg.checkpoint_dir
-
+class EffectiveRulesJob(cfg: ApplicationConfig) extends KafkaStreamingApplication(cfg) {
   def execute(): Unit = {
     with_context(cfg, { (ctx, sctx, input) =>
       input.map { s => s.reverse }
@@ -17,28 +12,7 @@ class EffectiveRulesJob(cfg: ApplicationConfig) extends KafkaStreamingApplicatio
 
 object EffectiveRulesJob {
   def main(args: Array[String]) : Unit = {
-    val job = new EffectiveRulesJob(EffectiveRulesJobConfig())
+    val job = new EffectiveRulesJob(ApplicationConfig("EffectiveRules"))
     job.execute()
-  }
-}
-
-object EffectiveRulesJobConfig {
-  import com.typesafe.config.Config
-  import com.typesafe.config.ConfigFactory
-  import net.ceedubs.ficus.Ficus._
-
-  def apply(): ApplicationConfig = apply(ConfigFactory.load)
-
-  def apply(app_cfg: Config): ApplicationConfig = {
-    val cfg = app_cfg.getConfig("EffectiveRules")
-    new ApplicationConfig(
-      cfg.as[String]("topics.input"),
-      cfg.as[String]("topics.output"),
-      cfg.as[Map[String, String]]("kafka.source"),
-      cfg.as[Map[String, String]]("kafka.sink"),
-      cfg.as[Map[String, String]]("spark"),
-      cfg.as[FiniteDuration]("batch_duration"),
-      cfg.as[String]("checkpoint_dir")
-    )
   }
 }


### PR DESCRIPTION
Connects to #22 

Each of the subdirectories in this project are effectively a copy of
each other with the content of a single Job.scala changed. With this
change, we should have a common KafkaStreamingApplication that can be
shared between jobs. The only side-effect of this change is that ALL
Spark jobs are now in the SAME JAR file and therefore must be invoked
with different main objects.